### PR TITLE
Do not save XML tree after each change (#69)

### DIFF
--- a/xml-tree-db/src/XMLTreeDBImpl.cpp
+++ b/xml-tree-db/src/XMLTreeDBImpl.cpp
@@ -42,6 +42,8 @@ void XMLTreeDBImpl::open(const boost::filesystem::path& path, Ishiko::Error& err
 
 void XMLTreeDBImpl::close()
 {
+    std::ofstream file(m_path.string());
+    m_document.save(file, "  ");
 }
 
 TreeDBNode& XMLTreeDBImpl::root()
@@ -274,8 +276,6 @@ size_t XMLTreeDBImpl::removeAllChildNodes(TreeDBNode& parent, Ishiko::Error& err
 void XMLTreeDBImpl::commitNode(XMLTreeDBNodeImpl& node, Ishiko::Error& error)
 {
     node.updateValue();
-    std::ofstream file(m_path.string());
-    m_document.save(file, "  ");
 }
 
 }


### PR DESCRIPTION
Saving the tree after each modification kills performance. We will only save the XML document on close. This makes it very unsafe in case of unexpected termination but this will have to wait until we put in place a journal file.